### PR TITLE
Integrate TravisBuddy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,11 @@ script: make travis
 
 ## Gather coverage and set it to coverage servers
 after_script: make travis-coverage
+
+notifications:
+  webhooks: http://www.travisbuddy.com/
+  on_success: never # default: always  
+  on_failure: always # default: always
+  on_start: never   # default: never
+  on_cancel: never # default: always
+  on_error: never # default: always


### PR DESCRIPTION
TravisBuddy will comment on pull requests in your public repository everytime a test failed in one of them. The comment will include only the part of the build log that applies to your testing framework, so your contirbutors won't have to enter Travis's website and search the long and annoying build log for the reason the tests failed.

Here's an example: https://github.com/bluzi/static-server/pull/1